### PR TITLE
Fix: #57 5일 이후 날씨 정보 불러오기 오류 수정 완료

### DIFF
--- a/src/js/api/ai.js
+++ b/src/js/api/ai.js
@@ -1,5 +1,24 @@
+/**
+ * 환경별 API Base URL 자동 설정
+ * - 개발 환경 (localhost): http://localhost:10000
+ * - 배포 환경 (production): https://aibe4-project1-team3.onrender.com
+ */
+const API_BASE = (() => {
+  const hostname = window.location.hostname;
+
+  // 로컬 개발 환경
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return "http://localhost:10000";
+  }
+
+  // 배포 환경 (Render)
+  return "https://aibe4-project1-team3.onrender.com";
+})();
+
 const USE_MOCK = false;
-const API_BASE = "https://aibe4-project1-team3.onrender.com";
+
+console.log(`[API Config] 현재 환경: ${window.location.hostname}`);
+console.log(`[API Config] API Base URL: ${API_BASE}`);
 
 /**
  * AI 여행 경로 추천 API 호출


### PR DESCRIPTION
## PR 컨벤션 (Pull Request Convention)

**Ⅰ. PR 내용 설명 (Describe what this PR did)**  
- 날씨 정보 API 연동 기능을 전면 수정하여 5일 이후의 날짜에 대한 AI 기반 날씨 정보 제공 오류(#57)를 해결하고, 개발 환경과 배포 환경의 API 엔드포인트를 자동 감지하도록 개선했습니다.

 1. 날씨 표시 범위 확장: 여행 날짜가 5일 이후인 경우, AI를 통해 생성되는 과거 평균 기후 데이터를 정상적으로 받아 표시할 수 있도록 수정했습니다. (5일 이내 → 모든 날짜)
 2. 환경 자동 감지: 백엔드 API 호출 시 하드 코딩되어 있던 환경별 URL을 자동으로 감지하여 개발과 베포 환경에 맞게 전환하도록 로직을 수정했습니다.
 
**Ⅱ. 관련 이슈 (Does this pull request fix one issue?)**  
fixes #57 

**Ⅲ. 검증 방법 (Describe how to verify it)**  
 1. 환경 URL 확인: (선택 사항) 서버 로그나 네트워크 탭을 통해 API 호출 URL이 로컬 환경(localhost 또는 개발 환경 주소)에 맞게 자동으로 설정되는지 확인합니다.
 2. 날씨 예보 검증 (핵심):
  - 현재 날짜 기준으로 6일 이후의 날짜를 선택하여 날씨 정보를 요청합니다.
  - 기대 결과: '날씨 정보를 불러올 수 없습니다.' 오류 대신, AI가 생성한 해당 도시/월의 평균 기후 데이터가 정상적으로 표시되어야 합니다.

**Ⅳ. 리뷰 시 참고 사항 (Special notes for reviews)**  
 1. AI 프롬프트 변경: 평균 날씨 데이터 생성 요청 프롬프트가 수정되었습니다. AI 응답이 예상하는 JSON/텍스트 형식으로 오는지 확인이 필요합니다.
 2. 환경 변수: API URL 자동 생성 로직이 환경 변수를 기반으로 정확하게 분기되는지 확인 부탁드립니다.
 3. 안전성: 이 수정 사항이 기존의 5일 이내 단기 예보 기능에 영향을 주지 않고 정상 작동하는지 함께 검증해 주시면 감사하겠습니다.
